### PR TITLE
fix vanilla-incompatible NPC patches

### DIFF
--- a/StarPounds/npcs/biome/frogmerchant.npctype.patch
+++ b/StarPounds/npcs/biome/frogmerchant.npctype.patch
@@ -1,41 +1,43 @@
 [
   [
-  {
-    "op": "test",
-    "path": "/nameGen"
-  },
-  {
-    "op": "remove",
-    "path": "/nameGen"
-  }
+    {
+      "op": "test",
+      "path": "/nameGen"
+    },
+    {
+      "op": "remove",
+      "path": "/nameGen"
+    }
   ],
-  {
-    "op": "add",
-    "path": "/identity",
-    "value": {
-      "species": "frogg"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/scriptConfig/merchant/categories/frogg",
-    "value": [
-      "frogmerchant"
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/items",
-    "value": {"override" : [
-      [0, [
-          {
-            "head" : [ { "name" : "froggfezhathead" } ],
-            "chest" : [ { "name" : "froggtraderchest" } ],
-            "legs" : [ { "name" : "froggtraderlegs" }  ],
-            "back" : [ "" ]
-          }
-        ] ]
+  [
+    {
+      "op": "add",
+      "path": "/identity",
+      "value": {
+        "species": "frogg"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/scriptConfig/merchant/categories/frogg",
+      "value": [
+        "frogmerchant"
       ]
+    },
+    {
+      "op": "add",
+      "path": "/items",
+      "value": {"override" : [
+        [0, [
+            {
+              "head" : [ { "name" : "froggfezhathead" } ],
+              "chest" : [ { "name" : "froggtraderchest" } ],
+              "legs" : [ { "name" : "froggtraderlegs" }  ],
+              "back" : [ "" ]
+            }
+          ] ]
+        ]
+      }
     }
-  }
+  ]
 ]

--- a/StarPounds/npcs/biome/frogvillager.npctype.patch
+++ b/StarPounds/npcs/biome/frogvillager.npctype.patch
@@ -1,34 +1,36 @@
 [
   [
-  {
-    "op": "test",
-    "path": "/nameGen"
-  },
-  {
-    "op": "remove",
-    "path": "/nameGen"
-  }
+    {
+      "op": "test",
+      "path": "/nameGen"
+    },
+    {
+      "op": "remove",
+      "path": "/nameGen"
+    }
   ],
-  {
-    "op": "add",
-    "path": "/identity",
-    "value": {
-      "species": "frogg"
+  [
+    {
+      "op": "add",
+      "path": "/identity",
+      "value": {
+        "species": "frogg"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/items",
+      "value": {"override" : [
+        [0, [
+            {
+              "head" : [ "" ],
+              "chest" : [ { "name" : "froggtrenchcoatchest" } ],
+              "legs" : [ { "name" : "froggtrenchcoatlegs" }  ],
+              "back" : [ "" ]
+            }
+          ] ]
+        ]
+      }
     }
-  },
-  {
-    "op": "add",
-    "path": "/items",
-    "value": {"override" : [
-      [0, [
-          {
-            "head" : [ "" ],
-            "chest" : [ { "name" : "froggtrenchcoatchest" } ],
-            "legs" : [ { "name" : "froggtrenchcoatlegs" }  ],
-            "back" : [ "" ]
-          }
-        ] ]
-      ]
-    }
-  }
+  ]
 ]

--- a/StarPounds/npcs/subbiometenants/frogtenantmerchant.npctype.patch
+++ b/StarPounds/npcs/subbiometenants/frogtenantmerchant.npctype.patch
@@ -1,19 +1,21 @@
 [
-[
-  {
-    "op": "test",
-    "path": "/nameGen"
-  },
-  {
-    "op": "remove",
-    "path": "/nameGen"
-  }
-],
-  {
-    "op": "add",
-    "path": "/scriptConfig/merchant/categories/frogg",
-    "value": [
-      "frogtenantmerchant"
-    ]
-  }
+  [
+    {
+      "op": "test",
+      "path": "/nameGen"
+    },
+    {
+      "op": "remove",
+      "path": "/nameGen"
+    }
+  ],
+  [
+    {
+      "op": "add",
+      "path": "/scriptConfig/merchant/categories/frogg",
+      "value": [
+        "frogtenantmerchant"
+      ]
+    }
+  ]
 ]


### PR DESCRIPTION
vanilla starbound expects JSON patch files to store either a flat list of patch operation objects, or a list of lists of patch operation objects. being able to mix loose patch operations alongside lists is an OpenStarbound extension and is not handled gracefully by vanilla starbound.